### PR TITLE
feat(MOBILE-26): Enhance ContentService with new RPC methods

### DIFF
--- a/lib/src/features/content/data/content_api_constants.dart
+++ b/lib/src/features/content/data/content_api_constants.dart
@@ -1,9 +1,9 @@
 abstract final class ContentApiConstants {
   // константы для реального сервера
-  // static const port = 30080;
-  // static const host = '109.196.98.55';
+  static const port = 30080;
+  static const host = '109.196.98.55';
 
   // константы для локального сервера
-  static const port = 8087;
-  static const host = '10.0.2.2';
+  // static const port = 8087;
+  // static const host = '10.0.2.2';
 }

--- a/lib/src/features/content/data/proto/content.proto
+++ b/lib/src/features/content/data/proto/content.proto
@@ -5,22 +5,26 @@ package content;
 option go_package = "pb/content";
 
 service ContentService {
-  rpc GetRoutes(GetRoutesRequest) returns (GetRoutesResponse) {}
+  rpc GetRoutes     (GetRoutesRequest)          returns (GetRoutesResponse) {}
+  rpc CreatePlace   (CreatePlaceRequest)        returns (CreatePlaceResponse) {}
+  rpc UploadImages  (stream UploadImageRequest) returns (UploadImageResponse) {}
+  rpc CreateRoute   (CreateRouteRequest)        returns (CreateRouteResponse) {}
 }
 
 message GetRoutesRequest {
   DifficultyFilter difficulty_filter = 1;
   DistanceFilter distance_filter = 2;
-}
-
-message DistanceFilter {
-  optional float min_km = 1;
-  optional float max_km = 2;
+  string search_query = 3;
 }
 
 message DifficultyFilter {
   optional DifficultyLevel min_difficulty = 1;
   optional DifficultyLevel max_difficulty = 2;
+}
+
+message DistanceFilter {
+  optional float min_km = 1;
+  optional float max_km = 2;
 }
 
 message GetRoutesResponse {
@@ -35,6 +39,7 @@ message Route {
   repeated Place places = 5;
   string user_id = 6; // UUID автора маршрута
   string route_id = 7; // UUID
+  string description = 8;
 }
 
 message Point {
@@ -60,4 +65,38 @@ enum DifficultyLevel {
   EASY = 0;
   MEDIUM = 1;
   HARD = 2;
+}
+
+message CreatePlaceRequest {
+  Point  location    = 1;
+  string name        = 2;
+  string address     = 3;
+  string description = 4;
+}
+
+message CreatePlaceResponse {
+  string place_id = 1;
+}
+
+message UploadImageRequest {
+  optional string place_id = 1; // UUID
+  string          filename = 2;
+  bytes           content  = 3;
+}
+
+message UploadImageResponse {
+  repeated Image images = 1;
+}
+
+message CreateRouteRequest {
+  string name = 1;
+  DifficultyLevel difficulty = 2;
+  float distance_km = 3;
+  repeated Point path_points = 4;
+  repeated string place_ids = 5; // UUIDs of associated places
+  string description = 6;
+}
+
+message CreateRouteResponse {
+  string route_id = 1; // UUID
 }

--- a/lib/src/features/content/domain/content_models_converter.dart
+++ b/lib/src/features/content/domain/content_models_converter.dart
@@ -18,6 +18,7 @@ final class ContentModelsConverterImpl implements ContentModelsConverter {
   @override
   RouteModel convertRouteToRouteModel(Route route) => RouteModel(
         name: route.name,
+        description: route.description,
         distanceKm: route.distanceKm,
         userId: route.userId,
         routeId: route.routeId,

--- a/lib/src/features/content/domain/models/route_model.dart
+++ b/lib/src/features/content/domain/models/route_model.dart
@@ -7,6 +7,7 @@ typedef RouteModels = Iterable<RouteModel>;
 
 final class RouteModel with EquatableMixin {
   final String name;
+  final String description;
   final double? distanceKm;
   final String? userId;
   final String routeId;
@@ -16,6 +17,7 @@ final class RouteModel with EquatableMixin {
 
   RouteModel({
     required this.name,
+    required this.description,
     required this.distanceKm,
     required this.userId,
     required this.routeId,
@@ -27,6 +29,7 @@ final class RouteModel with EquatableMixin {
   @override
   List<Object?> get props => [
         name,
+        description,
         distanceKm,
         userId,
         routeId,

--- a/lib/src/features/content/ui/content_page.dart
+++ b/lib/src/features/content/ui/content_page.dart
@@ -232,35 +232,12 @@ class _CardBodyWidget extends StatelessWidget {
               distanceKm: route.distanceKm,
             ),
             const SizedBox(height: 9),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                AppText(
-                  context.strings.placesOnRoute,
-                  style: Theme.of(context).textTheme.titleSmall,
-                ),
-                const SizedBox(height: 8),
-                ...route.places.map(
-                  (place) => Padding(
-                    padding: place != route.places.last
-                        ? const EdgeInsets.only(bottom: 8)
-                        : EdgeInsets.zero,
-                    child: Row(
-                      children: [
-                        const Icon(Icons.location_on, size: 16),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: AppText(
-                            place.name,
-                            color: context.colors.cardText,
-                            style: Theme.of(context).textTheme.bodyMedium,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ],
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: AppText(
+                route.description,
+                color: context.colors.minorText,
+              ),
             ),
           ],
         ),

--- a/lib/src/generated/lib/src/features/content/data/proto/content.pb.dart
+++ b/lib/src/generated/lib/src/features/content/data/proto/content.pb.dart
@@ -23,6 +23,7 @@ class GetRoutesRequest extends $pb.GeneratedMessage {
   factory GetRoutesRequest({
     DifficultyFilter? difficultyFilter,
     DistanceFilter? distanceFilter,
+    $core.String? searchQuery,
   }) {
     final $result = create();
     if (difficultyFilter != null) {
@@ -30,6 +31,9 @@ class GetRoutesRequest extends $pb.GeneratedMessage {
     }
     if (distanceFilter != null) {
       $result.distanceFilter = distanceFilter;
+    }
+    if (searchQuery != null) {
+      $result.searchQuery = searchQuery;
     }
     return $result;
   }
@@ -40,6 +44,7 @@ class GetRoutesRequest extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetRoutesRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'content'), createEmptyInstance: create)
     ..aOM<DifficultyFilter>(1, _omitFieldNames ? '' : 'difficultyFilter', subBuilder: DifficultyFilter.create)
     ..aOM<DistanceFilter>(2, _omitFieldNames ? '' : 'distanceFilter', subBuilder: DistanceFilter.create)
+    ..aOS(3, _omitFieldNames ? '' : 'searchQuery')
     ..hasRequiredFields = false
   ;
 
@@ -85,70 +90,15 @@ class GetRoutesRequest extends $pb.GeneratedMessage {
   void clearDistanceFilter() => $_clearField(2);
   @$pb.TagNumber(2)
   DistanceFilter ensureDistanceFilter() => $_ensure(1);
-}
 
-class DistanceFilter extends $pb.GeneratedMessage {
-  factory DistanceFilter({
-    $core.double? minKm,
-    $core.double? maxKm,
-  }) {
-    final $result = create();
-    if (minKm != null) {
-      $result.minKm = minKm;
-    }
-    if (maxKm != null) {
-      $result.maxKm = maxKm;
-    }
-    return $result;
-  }
-  DistanceFilter._() : super();
-  factory DistanceFilter.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory DistanceFilter.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DistanceFilter', package: const $pb.PackageName(_omitMessageNames ? '' : 'content'), createEmptyInstance: create)
-    ..a<$core.double>(1, _omitFieldNames ? '' : 'minKm', $pb.PbFieldType.OF)
-    ..a<$core.double>(2, _omitFieldNames ? '' : 'maxKm', $pb.PbFieldType.OF)
-    ..hasRequiredFields = false
-  ;
-
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  DistanceFilter clone() => DistanceFilter()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  DistanceFilter copyWith(void Function(DistanceFilter) updates) => super.copyWith((message) => updates(message as DistanceFilter)) as DistanceFilter;
-
-  $pb.BuilderInfo get info_ => _i;
-
-  @$core.pragma('dart2js:noInline')
-  static DistanceFilter create() => DistanceFilter._();
-  DistanceFilter createEmptyInstance() => create();
-  static $pb.PbList<DistanceFilter> createRepeated() => $pb.PbList<DistanceFilter>();
-  @$core.pragma('dart2js:noInline')
-  static DistanceFilter getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DistanceFilter>(create);
-  static DistanceFilter? _defaultInstance;
-
-  @$pb.TagNumber(1)
-  $core.double get minKm => $_getN(0);
-  @$pb.TagNumber(1)
-  set minKm($core.double v) { $_setFloat(0, v); }
-  @$pb.TagNumber(1)
-  $core.bool hasMinKm() => $_has(0);
-  @$pb.TagNumber(1)
-  void clearMinKm() => $_clearField(1);
-
-  @$pb.TagNumber(2)
-  $core.double get maxKm => $_getN(1);
-  @$pb.TagNumber(2)
-  set maxKm($core.double v) { $_setFloat(1, v); }
-  @$pb.TagNumber(2)
-  $core.bool hasMaxKm() => $_has(1);
-  @$pb.TagNumber(2)
-  void clearMaxKm() => $_clearField(2);
+  @$pb.TagNumber(3)
+  $core.String get searchQuery => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set searchQuery($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasSearchQuery() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearSearchQuery() => $_clearField(3);
 }
 
 class DifficultyFilter extends $pb.GeneratedMessage {
@@ -215,6 +165,70 @@ class DifficultyFilter extends $pb.GeneratedMessage {
   void clearMaxDifficulty() => $_clearField(2);
 }
 
+class DistanceFilter extends $pb.GeneratedMessage {
+  factory DistanceFilter({
+    $core.double? minKm,
+    $core.double? maxKm,
+  }) {
+    final $result = create();
+    if (minKm != null) {
+      $result.minKm = minKm;
+    }
+    if (maxKm != null) {
+      $result.maxKm = maxKm;
+    }
+    return $result;
+  }
+  DistanceFilter._() : super();
+  factory DistanceFilter.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DistanceFilter.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DistanceFilter', package: const $pb.PackageName(_omitMessageNames ? '' : 'content'), createEmptyInstance: create)
+    ..a<$core.double>(1, _omitFieldNames ? '' : 'minKm', $pb.PbFieldType.OF)
+    ..a<$core.double>(2, _omitFieldNames ? '' : 'maxKm', $pb.PbFieldType.OF)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DistanceFilter clone() => DistanceFilter()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DistanceFilter copyWith(void Function(DistanceFilter) updates) => super.copyWith((message) => updates(message as DistanceFilter)) as DistanceFilter;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DistanceFilter create() => DistanceFilter._();
+  DistanceFilter createEmptyInstance() => create();
+  static $pb.PbList<DistanceFilter> createRepeated() => $pb.PbList<DistanceFilter>();
+  @$core.pragma('dart2js:noInline')
+  static DistanceFilter getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DistanceFilter>(create);
+  static DistanceFilter? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.double get minKm => $_getN(0);
+  @$pb.TagNumber(1)
+  set minKm($core.double v) { $_setFloat(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasMinKm() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearMinKm() => $_clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.double get maxKm => $_getN(1);
+  @$pb.TagNumber(2)
+  set maxKm($core.double v) { $_setFloat(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMaxKm() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMaxKm() => $_clearField(2);
+}
+
 class GetRoutesResponse extends $pb.GeneratedMessage {
   factory GetRoutesResponse({
     $core.Iterable<Route>? routes,
@@ -268,6 +282,7 @@ class Route extends $pb.GeneratedMessage {
     $core.Iterable<Place>? places,
     $core.String? userId,
     $core.String? routeId,
+    $core.String? description,
   }) {
     final $result = create();
     if (difficulty != null) {
@@ -291,6 +306,9 @@ class Route extends $pb.GeneratedMessage {
     if (routeId != null) {
       $result.routeId = routeId;
     }
+    if (description != null) {
+      $result.description = description;
+    }
     return $result;
   }
   Route._() : super();
@@ -305,6 +323,7 @@ class Route extends $pb.GeneratedMessage {
     ..pc<Place>(5, _omitFieldNames ? '' : 'places', $pb.PbFieldType.PM, subBuilder: Place.create)
     ..aOS(6, _omitFieldNames ? '' : 'userId')
     ..aOS(7, _omitFieldNames ? '' : 'routeId')
+    ..aOS(8, _omitFieldNames ? '' : 'description')
     ..hasRequiredFields = false
   ;
 
@@ -379,6 +398,15 @@ class Route extends $pb.GeneratedMessage {
   $core.bool hasRouteId() => $_has(6);
   @$pb.TagNumber(7)
   void clearRouteId() => $_clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.String get description => $_getSZ(7);
+  @$pb.TagNumber(8)
+  set description($core.String v) { $_setString(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasDescription() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearDescription() => $_clearField(8);
 }
 
 class Point extends $pb.GeneratedMessage {
@@ -623,6 +651,430 @@ class Image extends $pb.GeneratedMessage {
   $core.bool hasPlaceholder() => $_has(1);
   @$pb.TagNumber(2)
   void clearPlaceholder() => $_clearField(2);
+}
+
+class CreatePlaceRequest extends $pb.GeneratedMessage {
+  factory CreatePlaceRequest({
+    Point? location,
+    $core.String? name,
+    $core.String? address,
+    $core.String? description,
+  }) {
+    final $result = create();
+    if (location != null) {
+      $result.location = location;
+    }
+    if (name != null) {
+      $result.name = name;
+    }
+    if (address != null) {
+      $result.address = address;
+    }
+    if (description != null) {
+      $result.description = description;
+    }
+    return $result;
+  }
+  CreatePlaceRequest._() : super();
+  factory CreatePlaceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreatePlaceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreatePlaceRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'content'), createEmptyInstance: create)
+    ..aOM<Point>(1, _omitFieldNames ? '' : 'location', subBuilder: Point.create)
+    ..aOS(2, _omitFieldNames ? '' : 'name')
+    ..aOS(3, _omitFieldNames ? '' : 'address')
+    ..aOS(4, _omitFieldNames ? '' : 'description')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CreatePlaceRequest clone() => CreatePlaceRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreatePlaceRequest copyWith(void Function(CreatePlaceRequest) updates) => super.copyWith((message) => updates(message as CreatePlaceRequest)) as CreatePlaceRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CreatePlaceRequest create() => CreatePlaceRequest._();
+  CreatePlaceRequest createEmptyInstance() => create();
+  static $pb.PbList<CreatePlaceRequest> createRepeated() => $pb.PbList<CreatePlaceRequest>();
+  @$core.pragma('dart2js:noInline')
+  static CreatePlaceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreatePlaceRequest>(create);
+  static CreatePlaceRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  Point get location => $_getN(0);
+  @$pb.TagNumber(1)
+  set location(Point v) { $_setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasLocation() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearLocation() => $_clearField(1);
+  @$pb.TagNumber(1)
+  Point ensureLocation() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $core.String get name => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set name($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasName() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearName() => $_clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get address => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set address($core.String v) { $_setString(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasAddress() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearAddress() => $_clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.String get description => $_getSZ(3);
+  @$pb.TagNumber(4)
+  set description($core.String v) { $_setString(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasDescription() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearDescription() => $_clearField(4);
+}
+
+class CreatePlaceResponse extends $pb.GeneratedMessage {
+  factory CreatePlaceResponse({
+    $core.String? placeId,
+  }) {
+    final $result = create();
+    if (placeId != null) {
+      $result.placeId = placeId;
+    }
+    return $result;
+  }
+  CreatePlaceResponse._() : super();
+  factory CreatePlaceResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreatePlaceResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreatePlaceResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'content'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'placeId')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CreatePlaceResponse clone() => CreatePlaceResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreatePlaceResponse copyWith(void Function(CreatePlaceResponse) updates) => super.copyWith((message) => updates(message as CreatePlaceResponse)) as CreatePlaceResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CreatePlaceResponse create() => CreatePlaceResponse._();
+  CreatePlaceResponse createEmptyInstance() => create();
+  static $pb.PbList<CreatePlaceResponse> createRepeated() => $pb.PbList<CreatePlaceResponse>();
+  @$core.pragma('dart2js:noInline')
+  static CreatePlaceResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreatePlaceResponse>(create);
+  static CreatePlaceResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get placeId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set placeId($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPlaceId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPlaceId() => $_clearField(1);
+}
+
+class UploadImageRequest extends $pb.GeneratedMessage {
+  factory UploadImageRequest({
+    $core.String? placeId,
+    $core.String? filename,
+    $core.List<$core.int>? content,
+  }) {
+    final $result = create();
+    if (placeId != null) {
+      $result.placeId = placeId;
+    }
+    if (filename != null) {
+      $result.filename = filename;
+    }
+    if (content != null) {
+      $result.content = content;
+    }
+    return $result;
+  }
+  UploadImageRequest._() : super();
+  factory UploadImageRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UploadImageRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UploadImageRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'content'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'placeId')
+    ..aOS(2, _omitFieldNames ? '' : 'filename')
+    ..a<$core.List<$core.int>>(3, _omitFieldNames ? '' : 'content', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  UploadImageRequest clone() => UploadImageRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  UploadImageRequest copyWith(void Function(UploadImageRequest) updates) => super.copyWith((message) => updates(message as UploadImageRequest)) as UploadImageRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static UploadImageRequest create() => UploadImageRequest._();
+  UploadImageRequest createEmptyInstance() => create();
+  static $pb.PbList<UploadImageRequest> createRepeated() => $pb.PbList<UploadImageRequest>();
+  @$core.pragma('dart2js:noInline')
+  static UploadImageRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UploadImageRequest>(create);
+  static UploadImageRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get placeId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set placeId($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasPlaceId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearPlaceId() => $_clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.String get filename => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set filename($core.String v) { $_setString(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasFilename() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearFilename() => $_clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.List<$core.int> get content => $_getN(2);
+  @$pb.TagNumber(3)
+  set content($core.List<$core.int> v) { $_setBytes(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasContent() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearContent() => $_clearField(3);
+}
+
+class UploadImageResponse extends $pb.GeneratedMessage {
+  factory UploadImageResponse({
+    $core.Iterable<Image>? images,
+  }) {
+    final $result = create();
+    if (images != null) {
+      $result.images.addAll(images);
+    }
+    return $result;
+  }
+  UploadImageResponse._() : super();
+  factory UploadImageResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory UploadImageResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'UploadImageResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'content'), createEmptyInstance: create)
+    ..pc<Image>(1, _omitFieldNames ? '' : 'images', $pb.PbFieldType.PM, subBuilder: Image.create)
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  UploadImageResponse clone() => UploadImageResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  UploadImageResponse copyWith(void Function(UploadImageResponse) updates) => super.copyWith((message) => updates(message as UploadImageResponse)) as UploadImageResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static UploadImageResponse create() => UploadImageResponse._();
+  UploadImageResponse createEmptyInstance() => create();
+  static $pb.PbList<UploadImageResponse> createRepeated() => $pb.PbList<UploadImageResponse>();
+  @$core.pragma('dart2js:noInline')
+  static UploadImageResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<UploadImageResponse>(create);
+  static UploadImageResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $pb.PbList<Image> get images => $_getList(0);
+}
+
+class CreateRouteRequest extends $pb.GeneratedMessage {
+  factory CreateRouteRequest({
+    $core.String? name,
+    DifficultyLevel? difficulty,
+    $core.double? distanceKm,
+    $core.Iterable<Point>? pathPoints,
+    $core.Iterable<$core.String>? placeIds,
+    $core.String? description,
+  }) {
+    final $result = create();
+    if (name != null) {
+      $result.name = name;
+    }
+    if (difficulty != null) {
+      $result.difficulty = difficulty;
+    }
+    if (distanceKm != null) {
+      $result.distanceKm = distanceKm;
+    }
+    if (pathPoints != null) {
+      $result.pathPoints.addAll(pathPoints);
+    }
+    if (placeIds != null) {
+      $result.placeIds.addAll(placeIds);
+    }
+    if (description != null) {
+      $result.description = description;
+    }
+    return $result;
+  }
+  CreateRouteRequest._() : super();
+  factory CreateRouteRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateRouteRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateRouteRequest', package: const $pb.PackageName(_omitMessageNames ? '' : 'content'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..e<DifficultyLevel>(2, _omitFieldNames ? '' : 'difficulty', $pb.PbFieldType.OE, defaultOrMaker: DifficultyLevel.EASY, valueOf: DifficultyLevel.valueOf, enumValues: DifficultyLevel.values)
+    ..a<$core.double>(3, _omitFieldNames ? '' : 'distanceKm', $pb.PbFieldType.OF)
+    ..pc<Point>(4, _omitFieldNames ? '' : 'pathPoints', $pb.PbFieldType.PM, subBuilder: Point.create)
+    ..pPS(5, _omitFieldNames ? '' : 'placeIds')
+    ..aOS(6, _omitFieldNames ? '' : 'description')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CreateRouteRequest clone() => CreateRouteRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateRouteRequest copyWith(void Function(CreateRouteRequest) updates) => super.copyWith((message) => updates(message as CreateRouteRequest)) as CreateRouteRequest;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CreateRouteRequest create() => CreateRouteRequest._();
+  CreateRouteRequest createEmptyInstance() => create();
+  static $pb.PbList<CreateRouteRequest> createRepeated() => $pb.PbList<CreateRouteRequest>();
+  @$core.pragma('dart2js:noInline')
+  static CreateRouteRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateRouteRequest>(create);
+  static CreateRouteRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearName() => $_clearField(1);
+
+  @$pb.TagNumber(2)
+  DifficultyLevel get difficulty => $_getN(1);
+  @$pb.TagNumber(2)
+  set difficulty(DifficultyLevel v) { $_setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasDifficulty() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearDifficulty() => $_clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.double get distanceKm => $_getN(2);
+  @$pb.TagNumber(3)
+  set distanceKm($core.double v) { $_setFloat(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasDistanceKm() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearDistanceKm() => $_clearField(3);
+
+  @$pb.TagNumber(4)
+  $pb.PbList<Point> get pathPoints => $_getList(3);
+
+  @$pb.TagNumber(5)
+  $pb.PbList<$core.String> get placeIds => $_getList(4);
+
+  @$pb.TagNumber(6)
+  $core.String get description => $_getSZ(5);
+  @$pb.TagNumber(6)
+  set description($core.String v) { $_setString(5, v); }
+  @$pb.TagNumber(6)
+  $core.bool hasDescription() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearDescription() => $_clearField(6);
+}
+
+class CreateRouteResponse extends $pb.GeneratedMessage {
+  factory CreateRouteResponse({
+    $core.String? routeId,
+  }) {
+    final $result = create();
+    if (routeId != null) {
+      $result.routeId = routeId;
+    }
+    return $result;
+  }
+  CreateRouteResponse._() : super();
+  factory CreateRouteResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CreateRouteResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'CreateRouteResponse', package: const $pb.PackageName(_omitMessageNames ? '' : 'content'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'routeId')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CreateRouteResponse clone() => CreateRouteResponse()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CreateRouteResponse copyWith(void Function(CreateRouteResponse) updates) => super.copyWith((message) => updates(message as CreateRouteResponse)) as CreateRouteResponse;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static CreateRouteResponse create() => CreateRouteResponse._();
+  CreateRouteResponse createEmptyInstance() => create();
+  static $pb.PbList<CreateRouteResponse> createRepeated() => $pb.PbList<CreateRouteResponse>();
+  @$core.pragma('dart2js:noInline')
+  static CreateRouteResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CreateRouteResponse>(create);
+  static CreateRouteResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get routeId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set routeId($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasRouteId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRouteId() => $_clearField(1);
 }
 
 

--- a/lib/src/generated/lib/src/features/content/data/proto/content.pbgrpc.dart
+++ b/lib/src/generated/lib/src/features/content/data/proto/content.pbgrpc.dart
@@ -25,6 +25,18 @@ class ContentServiceClient extends $grpc.Client {
       '/content.ContentService/GetRoutes',
       ($0.GetRoutesRequest value) => value.writeToBuffer(),
       ($core.List<$core.int> value) => $0.GetRoutesResponse.fromBuffer(value));
+  static final _$createPlace = $grpc.ClientMethod<$0.CreatePlaceRequest, $0.CreatePlaceResponse>(
+      '/content.ContentService/CreatePlace',
+      ($0.CreatePlaceRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.CreatePlaceResponse.fromBuffer(value));
+  static final _$uploadImages = $grpc.ClientMethod<$0.UploadImageRequest, $0.UploadImageResponse>(
+      '/content.ContentService/UploadImages',
+      ($0.UploadImageRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.UploadImageResponse.fromBuffer(value));
+  static final _$createRoute = $grpc.ClientMethod<$0.CreateRouteRequest, $0.CreateRouteResponse>(
+      '/content.ContentService/CreateRoute',
+      ($0.CreateRouteRequest value) => value.writeToBuffer(),
+      ($core.List<$core.int> value) => $0.CreateRouteResponse.fromBuffer(value));
 
   ContentServiceClient($grpc.ClientChannel channel,
       {$grpc.CallOptions? options,
@@ -34,6 +46,18 @@ class ContentServiceClient extends $grpc.Client {
 
   $grpc.ResponseFuture<$0.GetRoutesResponse> getRoutes($0.GetRoutesRequest request, {$grpc.CallOptions? options}) {
     return $createUnaryCall(_$getRoutes, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.CreatePlaceResponse> createPlace($0.CreatePlaceRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$createPlace, request, options: options);
+  }
+
+  $grpc.ResponseFuture<$0.UploadImageResponse> uploadImages($async.Stream<$0.UploadImageRequest> request, {$grpc.CallOptions? options}) {
+    return $createStreamingCall(_$uploadImages, request, options: options).single;
+  }
+
+  $grpc.ResponseFuture<$0.CreateRouteResponse> createRoute($0.CreateRouteRequest request, {$grpc.CallOptions? options}) {
+    return $createUnaryCall(_$createRoute, request, options: options);
   }
 }
 
@@ -49,11 +73,43 @@ abstract class ContentServiceBase extends $grpc.Service {
         false,
         ($core.List<$core.int> value) => $0.GetRoutesRequest.fromBuffer(value),
         ($0.GetRoutesResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.CreatePlaceRequest, $0.CreatePlaceResponse>(
+        'CreatePlace',
+        createPlace_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.CreatePlaceRequest.fromBuffer(value),
+        ($0.CreatePlaceResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.UploadImageRequest, $0.UploadImageResponse>(
+        'UploadImages',
+        uploadImages,
+        true,
+        false,
+        ($core.List<$core.int> value) => $0.UploadImageRequest.fromBuffer(value),
+        ($0.UploadImageResponse value) => value.writeToBuffer()));
+    $addMethod($grpc.ServiceMethod<$0.CreateRouteRequest, $0.CreateRouteResponse>(
+        'CreateRoute',
+        createRoute_Pre,
+        false,
+        false,
+        ($core.List<$core.int> value) => $0.CreateRouteRequest.fromBuffer(value),
+        ($0.CreateRouteResponse value) => value.writeToBuffer()));
   }
 
   $async.Future<$0.GetRoutesResponse> getRoutes_Pre($grpc.ServiceCall $call, $async.Future<$0.GetRoutesRequest> $request) async {
     return getRoutes($call, await $request);
   }
 
+  $async.Future<$0.CreatePlaceResponse> createPlace_Pre($grpc.ServiceCall $call, $async.Future<$0.CreatePlaceRequest> $request) async {
+    return createPlace($call, await $request);
+  }
+
+  $async.Future<$0.CreateRouteResponse> createRoute_Pre($grpc.ServiceCall $call, $async.Future<$0.CreateRouteRequest> $request) async {
+    return createRoute($call, await $request);
+  }
+
   $async.Future<$0.GetRoutesResponse> getRoutes($grpc.ServiceCall call, $0.GetRoutesRequest request);
+  $async.Future<$0.CreatePlaceResponse> createPlace($grpc.ServiceCall call, $0.CreatePlaceRequest request);
+  $async.Future<$0.UploadImageResponse> uploadImages($grpc.ServiceCall call, $async.Stream<$0.UploadImageRequest> request);
+  $async.Future<$0.CreateRouteResponse> createRoute($grpc.ServiceCall call, $0.CreateRouteRequest request);
 }

--- a/lib/src/generated/lib/src/features/content/data/proto/content.pbjson.dart
+++ b/lib/src/generated/lib/src/features/content/data/proto/content.pbjson.dart
@@ -33,6 +33,7 @@ const GetRoutesRequest$json = {
   '2': [
     {'1': 'difficulty_filter', '3': 1, '4': 1, '5': 11, '6': '.content.DifficultyFilter', '10': 'difficultyFilter'},
     {'1': 'distance_filter', '3': 2, '4': 1, '5': 11, '6': '.content.DistanceFilter', '10': 'distanceFilter'},
+    {'1': 'search_query', '3': 3, '4': 1, '5': 9, '10': 'searchQuery'},
   ],
 };
 
@@ -40,25 +41,8 @@ const GetRoutesRequest$json = {
 final $typed_data.Uint8List getRoutesRequestDescriptor = $convert.base64Decode(
     'ChBHZXRSb3V0ZXNSZXF1ZXN0EkYKEWRpZmZpY3VsdHlfZmlsdGVyGAEgASgLMhkuY29udGVudC'
     '5EaWZmaWN1bHR5RmlsdGVyUhBkaWZmaWN1bHR5RmlsdGVyEkAKD2Rpc3RhbmNlX2ZpbHRlchgC'
-    'IAEoCzIXLmNvbnRlbnQuRGlzdGFuY2VGaWx0ZXJSDmRpc3RhbmNlRmlsdGVy');
-
-@$core.Deprecated('Use distanceFilterDescriptor instead')
-const DistanceFilter$json = {
-  '1': 'DistanceFilter',
-  '2': [
-    {'1': 'min_km', '3': 1, '4': 1, '5': 2, '9': 0, '10': 'minKm', '17': true},
-    {'1': 'max_km', '3': 2, '4': 1, '5': 2, '9': 1, '10': 'maxKm', '17': true},
-  ],
-  '8': [
-    {'1': '_min_km'},
-    {'1': '_max_km'},
-  ],
-};
-
-/// Descriptor for `DistanceFilter`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List distanceFilterDescriptor = $convert.base64Decode(
-    'Cg5EaXN0YW5jZUZpbHRlchIaCgZtaW5fa20YASABKAJIAFIFbWluS22IAQESGgoGbWF4X2ttGA'
-    'IgASgCSAFSBW1heEttiAEBQgkKB19taW5fa21CCQoHX21heF9rbQ==');
+    'IAEoCzIXLmNvbnRlbnQuRGlzdGFuY2VGaWx0ZXJSDmRpc3RhbmNlRmlsdGVyEiEKDHNlYXJjaF'
+    '9xdWVyeRgDIAEoCVILc2VhcmNoUXVlcnk=');
 
 @$core.Deprecated('Use difficultyFilterDescriptor instead')
 const DifficultyFilter$json = {
@@ -79,6 +63,24 @@ final $typed_data.Uint8List difficultyFilterDescriptor = $convert.base64Decode(
     'ZmaWN1bHR5TGV2ZWxIAFINbWluRGlmZmljdWx0eYgBARJECg5tYXhfZGlmZmljdWx0eRgCIAEo'
     'DjIYLmNvbnRlbnQuRGlmZmljdWx0eUxldmVsSAFSDW1heERpZmZpY3VsdHmIAQFCEQoPX21pbl'
     '9kaWZmaWN1bHR5QhEKD19tYXhfZGlmZmljdWx0eQ==');
+
+@$core.Deprecated('Use distanceFilterDescriptor instead')
+const DistanceFilter$json = {
+  '1': 'DistanceFilter',
+  '2': [
+    {'1': 'min_km', '3': 1, '4': 1, '5': 2, '9': 0, '10': 'minKm', '17': true},
+    {'1': 'max_km', '3': 2, '4': 1, '5': 2, '9': 1, '10': 'maxKm', '17': true},
+  ],
+  '8': [
+    {'1': '_min_km'},
+    {'1': '_max_km'},
+  ],
+};
+
+/// Descriptor for `DistanceFilter`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List distanceFilterDescriptor = $convert.base64Decode(
+    'Cg5EaXN0YW5jZUZpbHRlchIaCgZtaW5fa20YASABKAJIAFIFbWluS22IAQESGgoGbWF4X2ttGA'
+    'IgASgCSAFSBW1heEttiAEBQgkKB19taW5fa21CCQoHX21heF9rbQ==');
 
 @$core.Deprecated('Use getRoutesResponseDescriptor instead')
 const GetRoutesResponse$json = {
@@ -104,6 +106,7 @@ const Route$json = {
     {'1': 'places', '3': 5, '4': 3, '5': 11, '6': '.content.Place', '10': 'places'},
     {'1': 'user_id', '3': 6, '4': 1, '5': 9, '10': 'userId'},
     {'1': 'route_id', '3': 7, '4': 1, '5': 9, '10': 'routeId'},
+    {'1': 'description', '3': 8, '4': 1, '5': 9, '10': 'description'},
   ],
 };
 
@@ -113,7 +116,8 @@ final $typed_data.Uint8List routeDescriptor = $convert.base64Decode(
     'RpZmZpY3VsdHkSHwoLZGlzdGFuY2Vfa20YAiABKAJSCmRpc3RhbmNlS20SEgoEbmFtZRgDIAEo'
     'CVIEbmFtZRIvCgtwYXRoX3BvaW50cxgEIAMoCzIOLmNvbnRlbnQuUG9pbnRSCnBhdGhQb2ludH'
     'MSJgoGcGxhY2VzGAUgAygLMg4uY29udGVudC5QbGFjZVIGcGxhY2VzEhcKB3VzZXJfaWQYBiAB'
-    'KAlSBnVzZXJJZBIZCghyb3V0ZV9pZBgHIAEoCVIHcm91dGVJZA==');
+    'KAlSBnVzZXJJZBIZCghyb3V0ZV9pZBgHIAEoCVIHcm91dGVJZBIgCgtkZXNjcmlwdGlvbhgIIA'
+    'EoCVILZGVzY3JpcHRpb24=');
 
 @$core.Deprecated('Use pointDescriptor instead')
 const Point$json = {
@@ -161,4 +165,98 @@ const Image$json = {
 final $typed_data.Uint8List imageDescriptor = $convert.base64Decode(
     'CgVJbWFnZRIQCgN1cmwYASABKAlSA3VybBIgCgtwbGFjZWhvbGRlchgCIAEoCVILcGxhY2Vob2'
     'xkZXI=');
+
+@$core.Deprecated('Use createPlaceRequestDescriptor instead')
+const CreatePlaceRequest$json = {
+  '1': 'CreatePlaceRequest',
+  '2': [
+    {'1': 'location', '3': 1, '4': 1, '5': 11, '6': '.content.Point', '10': 'location'},
+    {'1': 'name', '3': 2, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'address', '3': 3, '4': 1, '5': 9, '10': 'address'},
+    {'1': 'description', '3': 4, '4': 1, '5': 9, '10': 'description'},
+  ],
+};
+
+/// Descriptor for `CreatePlaceRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List createPlaceRequestDescriptor = $convert.base64Decode(
+    'ChJDcmVhdGVQbGFjZVJlcXVlc3QSKgoIbG9jYXRpb24YASABKAsyDi5jb250ZW50LlBvaW50Ug'
+    'hsb2NhdGlvbhISCgRuYW1lGAIgASgJUgRuYW1lEhgKB2FkZHJlc3MYAyABKAlSB2FkZHJlc3MS'
+    'IAoLZGVzY3JpcHRpb24YBCABKAlSC2Rlc2NyaXB0aW9u');
+
+@$core.Deprecated('Use createPlaceResponseDescriptor instead')
+const CreatePlaceResponse$json = {
+  '1': 'CreatePlaceResponse',
+  '2': [
+    {'1': 'place_id', '3': 1, '4': 1, '5': 9, '10': 'placeId'},
+  ],
+};
+
+/// Descriptor for `CreatePlaceResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List createPlaceResponseDescriptor = $convert.base64Decode(
+    'ChNDcmVhdGVQbGFjZVJlc3BvbnNlEhkKCHBsYWNlX2lkGAEgASgJUgdwbGFjZUlk');
+
+@$core.Deprecated('Use uploadImageRequestDescriptor instead')
+const UploadImageRequest$json = {
+  '1': 'UploadImageRequest',
+  '2': [
+    {'1': 'place_id', '3': 1, '4': 1, '5': 9, '9': 0, '10': 'placeId', '17': true},
+    {'1': 'filename', '3': 2, '4': 1, '5': 9, '10': 'filename'},
+    {'1': 'content', '3': 3, '4': 1, '5': 12, '10': 'content'},
+  ],
+  '8': [
+    {'1': '_place_id'},
+  ],
+};
+
+/// Descriptor for `UploadImageRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List uploadImageRequestDescriptor = $convert.base64Decode(
+    'ChJVcGxvYWRJbWFnZVJlcXVlc3QSHgoIcGxhY2VfaWQYASABKAlIAFIHcGxhY2VJZIgBARIaCg'
+    'hmaWxlbmFtZRgCIAEoCVIIZmlsZW5hbWUSGAoHY29udGVudBgDIAEoDFIHY29udGVudEILCglf'
+    'cGxhY2VfaWQ=');
+
+@$core.Deprecated('Use uploadImageResponseDescriptor instead')
+const UploadImageResponse$json = {
+  '1': 'UploadImageResponse',
+  '2': [
+    {'1': 'images', '3': 1, '4': 3, '5': 11, '6': '.content.Image', '10': 'images'},
+  ],
+};
+
+/// Descriptor for `UploadImageResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List uploadImageResponseDescriptor = $convert.base64Decode(
+    'ChNVcGxvYWRJbWFnZVJlc3BvbnNlEiYKBmltYWdlcxgBIAMoCzIOLmNvbnRlbnQuSW1hZ2VSBm'
+    'ltYWdlcw==');
+
+@$core.Deprecated('Use createRouteRequestDescriptor instead')
+const CreateRouteRequest$json = {
+  '1': 'CreateRouteRequest',
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'difficulty', '3': 2, '4': 1, '5': 14, '6': '.content.DifficultyLevel', '10': 'difficulty'},
+    {'1': 'distance_km', '3': 3, '4': 1, '5': 2, '10': 'distanceKm'},
+    {'1': 'path_points', '3': 4, '4': 3, '5': 11, '6': '.content.Point', '10': 'pathPoints'},
+    {'1': 'place_ids', '3': 5, '4': 3, '5': 9, '10': 'placeIds'},
+    {'1': 'description', '3': 6, '4': 1, '5': 9, '10': 'description'},
+  ],
+};
+
+/// Descriptor for `CreateRouteRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List createRouteRequestDescriptor = $convert.base64Decode(
+    'ChJDcmVhdGVSb3V0ZVJlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZRI4CgpkaWZmaWN1bHR5GA'
+    'IgASgOMhguY29udGVudC5EaWZmaWN1bHR5TGV2ZWxSCmRpZmZpY3VsdHkSHwoLZGlzdGFuY2Vf'
+    'a20YAyABKAJSCmRpc3RhbmNlS20SLwoLcGF0aF9wb2ludHMYBCADKAsyDi5jb250ZW50LlBvaW'
+    '50UgpwYXRoUG9pbnRzEhsKCXBsYWNlX2lkcxgFIAMoCVIIcGxhY2VJZHMSIAoLZGVzY3JpcHRp'
+    'b24YBiABKAlSC2Rlc2NyaXB0aW9u');
+
+@$core.Deprecated('Use createRouteResponseDescriptor instead')
+const CreateRouteResponse$json = {
+  '1': 'CreateRouteResponse',
+  '2': [
+    {'1': 'route_id', '3': 1, '4': 1, '5': 9, '10': 'routeId'},
+  ],
+};
+
+/// Descriptor for `CreateRouteResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List createRouteResponseDescriptor = $convert.base64Decode(
+    'ChNDcmVhdGVSb3V0ZVJlc3BvbnNlEhkKCHJvdXRlX2lkGAEgASgJUgdyb3V0ZUlk');
 

--- a/lib/src/mock_server/mock_content_service.dart
+++ b/lib/src/mock_server/mock_content_service.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: lines_longer_than_80_chars
+
 import 'package:flutter_travel_app/src/common/utils/named_logger_factory.dart';
 import 'package:flutter_travel_app/src/generated/lib/src/features/content/data/proto/content.pbgrpc.dart';
 import 'package:grpc/grpc.dart';
@@ -30,6 +32,8 @@ class MockRoutesContentService extends ContentServiceBase {
               Point(lat: 43.585472, lon: 39.723099),
               Point(lat: 43.563217, lon: 39.808642),
             ],
+            description:
+                'Самый сложный маршрут в городе, с высокими горами и водопадами. Вы будуете вымотаны еще в середине пути, но зато станете сильнее и сможете потом тащить самые сложные таски. Вы можете потеряться в горах, но мы вас найдем, потому что вы арендовали наше оборудование.',
             places: [
               Place()
                 ..name = 'Пик Горный'
@@ -75,6 +79,8 @@ class MockRoutesContentService extends ContentServiceBase {
               Point(lat: 43.585472, lon: 39.723099),
               Point(lat: 43.579536, lon: 39.724925),
             ],
+            description:
+                'Самый простой маршрут в городе, с красивыми фонтанами и музеями. Вы кайфанете и увидите много красивых мест. Вас обольет машина из лужи, но вы не утонете. Вас обгонит ближайший трамвай, но вы не Наташа.',
             places: [
               Place()
                 ..name = 'Главная площадь'
@@ -129,6 +135,7 @@ class MockRoutesContentService extends ContentServiceBase {
 
   Route _createMockRoute({
     required String name,
+    required String description,
     required DifficultyLevel difficulty,
     required double distance,
     required List<Point> points,
@@ -136,6 +143,7 @@ class MockRoutesContentService extends ContentServiceBase {
   }) {
     return Route()
       ..name = name
+      ..description = description
       ..difficulty = difficulty
       ..distanceKm = distance
       ..pathPoints.addAll(points)
@@ -185,4 +193,28 @@ class MockRoutesContentService extends ContentServiceBase {
   void clearRoutes() => _mockRoutes.clear();
   void setErrorState({required bool state}) => shouldThrowError = state;
   void setResponseDelay(Duration delay) => responseDelay = delay;
+
+  @override
+  Future<CreatePlaceResponse> createPlace(
+    ServiceCall call,
+    CreatePlaceRequest request,
+  ) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<CreateRouteResponse> createRoute(
+    ServiceCall call,
+    CreateRouteRequest request,
+  ) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<UploadImageResponse> uploadImages(
+    ServiceCall call,
+    Stream<UploadImageRequest> request,
+  ) {
+    throw UnimplementedError();
+  }
 }


### PR DESCRIPTION
…te data models

- Added new RPC methods: CreatePlace, UploadImages, and CreateRoute to ContentService.
- Updated content.proto to include new request and response messages for these methods.
- Modified RouteModel to include a description field.
- Updated ContentModelsConverter to handle the new description field in Route.
- Enhanced UI to display route descriptions.
- Updated mock server to support new functionalities and provide mock responses for the new methods.